### PR TITLE
update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 ENV TERM=xterm
-
+ENV ARCH "dpkg --print-architecture"
 EXPOSE 80 443
 
-RUN if [ $(uname -p) = "aarch64" ]; then export ARCH=arm64 ; else export ARCH=$(uname -p); fi && \
+RUN export ARCH=$(dpkg --print-architecture)  &&\
     apt-get -yqq update  && \
     apt-get -yqq --no-install-recommends install  \
     zsh  sudo  rsync  dnsutils  supervisor  curl  wget  iproute2  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,18 @@ ENV TERM=xterm
 
 EXPOSE 80 443
 
-RUN apt-get -yqq update  && \
+RUN if [ $(uname -p) = "aarch64" ]; then export ARCH=arm64 ; else export ARCH=$(uname -p); fi && \
+    apt-get -yqq update  && \
     apt-get -yqq --no-install-recommends install  \
-      zsh  sudo  rsync  dnsutils  supervisor  curl  wget \
-      apt-transport-https  ca-certificates  software-properties-common  gpgv2  gpg-agent && \
+    zsh  sudo  rsync  dnsutils  supervisor  curl  wget  iproute2  \
+    apt-transport-https  ca-certificates  software-properties-common  gpgv2  gpg-agent && \
     # install binaries and service files
     #   eg: /usr/bin/nomad  /etc/nomad.d/nomad.hcl  /usr/lib/systemd/system/nomad.service
     curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
-    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
+    apt-add-repository "deb [arch=$ARCH] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
     apt-get -yqq update  && \
     apt-get -yqq install  nomad  consul  consul-template  && \
-    wget -qO /usr/bin/caddy 'https://caddyserver.com/api/download?os=linux&arch=amd64'  && \
+    wget -qO /usr/bin/caddy "https://caddyserver.com/api/download?os=linux&arch=$ARCH"  && \
     chmod +x /usr/bin/caddy
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 ENV TERM=xterm
 ENV ARCH "dpkg --print-architecture"
+
 EXPOSE 80 443
 
 RUN export ARCH=$(dpkg --print-architecture)  &&\
@@ -19,7 +20,6 @@ RUN export ARCH=$(dpkg --print-architecture)  &&\
     apt-get -yqq install  nomad  consul  consul-template  && \
     wget -qO /usr/bin/caddy "https://caddyserver.com/api/download?os=linux&arch=$ARCH"  && \
     chmod +x /usr/bin/caddy
-
 
 WORKDIR /app
 COPY   bin/install-docker-ce.sh bin/

--- a/bin/install-docker-ce.sh
+++ b/bin/install-docker-ce.sh
@@ -2,7 +2,6 @@
 
 # Installs latest stable docker-ce version for current ubuntu OS.
 
-
 [ "$( docker -v 2> /dev/null )" = "" ]  ||  echo 'docker already installed - exiting'
 [ "$( docker -v 2> /dev/null )" = "" ]  ||  exit 0
 

--- a/bin/install-docker-ce.sh
+++ b/bin/install-docker-ce.sh
@@ -2,10 +2,6 @@
 
 # Installs latest stable docker-ce version for current ubuntu OS.
 
-if [ $(uname -p) = "aarch64" ]; then
-  export ARCH=arm64 ; else
-  export ARCH=$(uname -p)
-fi
 
 [ "$( docker -v 2> /dev/null )" = "" ]  ||  echo 'docker already installed - exiting'
 [ "$( docker -v 2> /dev/null )" = "" ]  ||  exit 0
@@ -21,7 +17,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo apt-key fingerprint 0EBFCD88
 
 echo \
-  "deb [arch=$ARCH] https://download.docker.com/linux/ubuntu \
+  "deb [arch=$($ARCH)] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) \
   stable" | sudo tee /etc/apt/sources.list.d/download_docker_com_linux_ubuntu.list
 

--- a/bin/install-docker-ce.sh
+++ b/bin/install-docker-ce.sh
@@ -2,6 +2,11 @@
 
 # Installs latest stable docker-ce version for current ubuntu OS.
 
+if [ $(uname -p) = "aarch64" ]; then
+  export ARCH=arm64 ; else
+  export ARCH=$(uname -p)
+fi
+
 [ "$( docker -v 2> /dev/null )" = "" ]  ||  echo 'docker already installed - exiting'
 [ "$( docker -v 2> /dev/null )" = "" ]  ||  exit 0
 
@@ -16,7 +21,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo apt-key fingerprint 0EBFCD88
 
 echo \
-  "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+  "deb [arch=$ARCH] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) \
   stable" | sudo tee /etc/apt/sources.list.d/download_docker_com_linux_ubuntu.list
 


### PR DESCRIPTION
update to use dpkg --print-architecture (as suggested by Tracy), export environment variable such that can be used where may be required
see install-docker-ce.sh for example of further use.
tested on:
    win 11 docker-desktop x86_64
    mac latest os/docker-desktop arm64 (M1 max & M1 air)
    linux ubuntu latest with docker ce (x86_64 & armv8)