### PR TITLE
Use ip_hash as lb_policy

### DIFF
--- a/etc/Caddyfile.ctmpl
+++ b/etc/Caddyfile.ctmpl
@@ -30,6 +30,7 @@ http:// {
     {{ end }}
 
     reverse_proxy localhost:4646
+    lb_policy ip_hash
     {{ if ne (env "ON_DEMAND_TLS_ASK") "" }}
       tls {
         on_demand
@@ -47,6 +48,7 @@ http:// {
   {{- if . | regexMatch "^https://" -}}
     {{ $hosty }} {
       reverse_proxy localhost:{{ $port }}
+      lb_policy ip_hash
       {{ if ne (env "ON_DEMAND_TLS_ASK") "" }}
         tls {
           on_demand
@@ -57,10 +59,12 @@ http:// {
   {{ else if . | regexMatch "^http://" }}
     {{ $hosty }} {
       reverse_proxy localhost:{{ $port }}
+      lb_policy ip_hash
     }
   {{ else }}
     https://{{ $hosty }} {
       reverse_proxy localhost:{{ $port }}
+      lb_policy ip_hash
       {{ if ne (env "ON_DEMAND_TLS_ASK") "" }}
         tls {
           on_demand
@@ -97,7 +101,7 @@ http:// {
         {{ end }}
 
         reverse_proxy {{ range $services }} {{ .Address }}:{{ .Port }} {{ end }} {
-          lb_policy least_conn
+          lb_policy ip_hash
           trusted_proxies {{ env "TRUSTED_PROXIES" }}
         }
         {{ if ne (env "ON_DEMAND_TLS_ASK") "" }}
@@ -115,7 +119,7 @@ http:// {
             redir @redir https://{host}{uri} permanent
 
             reverse_proxy {{ range $services }} {{ .Address }}:{{ .Port }} {{ end }} {
-              lb_policy least_conn
+              lb_policy ip_hash
               trusted_proxies {{ env "TRUSTED_PROXIES" }}
             }
             log


### PR DESCRIPTION
On the theory that the existing lb_policy options are sometimes causing issues with WebSockets in Nomad (and therefore wih the web UI exec functionality), try using `lb_policy ip_hash` so that packets from a particular client IP are always sent to the same Nomad server.

See also:
https://developer.hashicorp.com/nomad/tutorials/manage-clusters/reverse-proxy-ui#enable-websocket-connections