### PR TITLE
Feature: increase startretries

### DIFF
--- a/etc/supervisord.conf
+++ b/etc/supervisord.conf
@@ -1,23 +1,27 @@
 [program:nomad]
 command=/usr/bin/nomad  agent -config     /etc/nomad.d
 autorestart=true
+startretries=10
 startsecs=10
 
 [program:consul]
 command=/usr/bin/consul agent -config-dir=/etc/consul.d/
 autorestart=true
+startretries=10
 startsecs=10
 
 [program:caddy]
 directory=/etc
 command=/usr/bin/caddy run
 autorestart=true
+startretries=10
 startsecs=10
 
 [program:consul-template]
 directory=/etc
 command=/usr/bin/consul-template -template "/etc/Caddyfile.ctmpl:/etc/Caddyfile:/bin/bash -c 'cd /etc; /usr/bin/caddy fmt --overwrite; /usr/bin/caddy reload || true'"
 autorestart=true
+startretries=10
 startsecs=10
 
 # Every 12h, restart cluster load balancer.
@@ -26,3 +30,4 @@ startsecs=10
 directory=/etc/supervisor
 command=/bin/bash -c '/bin/sleep 43200  &&  /bin/supervisorctl restart caddy'
 autorestart=true
+startretries=10


### PR DESCRIPTION
Increase `startretries` to 10, from the default 3.

This change is being made because sometimes consul-template ends up in a `FATAL` state with the message:
`Exited too quickly (process log may have details)`

When this happens, `supervisorctl start consul-template` appears to work, so perhaps it simply needs more tries at restarting.

See https://supervisord.org/configuration.html